### PR TITLE
Refactor tests and improve coverage

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -7,7 +7,7 @@ export default class ImageCaption extends React.Component {
       className: React.PropTypes.string,
       caption: React.PropTypes.string,
       src: React.PropTypes.string.isRequired,
-      srcset: React.PropTypes.string,
+      srcSet: React.PropTypes.string,
       alt: React.PropTypes.string,
     };
   }
@@ -19,10 +19,13 @@ export default class ImageCaption extends React.Component {
   }
 
   render() {
-    const figcaption = (this.props.caption) ? <figcaption>{this.props.caption}</figcaption> : '';
+    let figcaption = null;
+    if (this.props.caption) {
+      figcaption = (<figcaption>{this.props.caption}</figcaption>);
+    }
     return (
       <figure className={this.props.className}>
-         <img src={this.props.src} srcSet={this.props.srcset} alt={this.props.alt} />
+         <img src={this.props.src} srcSet={this.props.srcSet} alt={this.props.alt} />
          {figcaption}
       </figure>
     );

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       {
         "contents": "chai.should();mocha.setup('bdd');"
       },
-      "/test/index.es6?babelify&debug&external=react",
+      "/test/index.es6?babelify&debug",
       {
         "contents": "mocha.checkLeaks();mocha.run();"
       }
@@ -65,7 +65,7 @@
     "provision": "devpack-configure ./package.json",
     "serve": "component-devserver .",
     "test": "npm run test:base -- -R tap",
-    "test:base": "mocha -r babel/register -r @economist/component-testharness",
+    "test:base": "mocha -r babel/register -r @economist/component-testharness test/*.es6",
     "test:watch": "npm run test:base -- -wR min"
   },
   "dependencies": {

--- a/test/index.es6
+++ b/test/index.es6
@@ -1,63 +1,121 @@
 import ImageCaption from './../index.es6';
-import React from 'react';
+import React from 'react/addons';
 const TestUtils = React.addons.TestUtils;
 describe('ImageCaption', () => {
-  it('should exist', () => {
-    ImageCaption.should.be.a('function');
+  it('is compatible with React.Component', () => {
+    ImageCaption.should.be.a('function')
+      .and.respondTo('render');
   });
 
-  it('renders a component', () => {
-    (<ImageCaption/>).should.be.an('object');
-  });
-});
-
-describe('Rendering', () => {
-  const renderer = TestUtils.createRenderer();
-  let component;
-  beforeEach(() => {
-    component = renderer.render(React.createElement(ImageCaption, {
-      caption: 'A caption',
-      src: 'src',
-      srcset: 'srcset',
-      alt: 'An alt attribute for the img',
-    }));
-    component = renderer.getRenderOutput();
+  it('renders a React element', () => {
+    React.isValidElement(<ImageCaption/>).should.equal(true);
   });
 
-  it('renders a figure.ImageCaption', () => {
-    component
-      .should.have.property('type', 'figure');
-    component
-      .should.have.deep.property('props.className', 'ImageCaption');
-  });
+  describe('Rendering', () => {
+    const renderer = TestUtils.createRenderer();
+    it('renders a figure.ImageCaption with an img and figcaption', () => {
+      renderer.render(<ImageCaption
+        caption="A caption"
+        src="src"
+        srcSet="srcset"
+        alt="An alt attribute for the img"
+      />, {});
+      renderer.getRenderOutput().should.deep.equal(
+        <figure className="ImageCaption">
+          <img src="src" srcSet="srcset" alt="An alt attribute for the img"/>
+          <figcaption>A caption</figcaption>
+        </figure>
+      );
+    });
 
-  it('renders a <img />', () => {
-    component
-      .should.have.deep.property('props.children[0].type', 'img');
-  });
+    it('allows overriding of className', () => {
+      renderer.render(<ImageCaption
+        className="foobar"
+        caption="A caption"
+        src="src"
+        srcSet="srcset"
+        alt="An alt attribute for the img"
+      />, {});
+      renderer.getRenderOutput().should.deep.equal(
+        <figure className="foobar">
+          <img src="src" srcSet="srcset" alt="An alt attribute for the img"/>
+          <figcaption>A caption</figcaption>
+        </figure>
+      );
+    });
 
-  it('renders a <img src="src" />', () => {
-    component
-      .should.have.deep.property('props.children[0].props.src', 'src');
-  });
+    it('reflects props.src to the <img> tag', () => {
+      renderer.render(<ImageCaption
+        caption="A caption"
+        src="foobar"
+        srcSet="srcset"
+        alt="An alt attribute for the img"
+      />, {});
+      renderer.getRenderOutput().should.deep.equal(
+          <figure className="ImageCaption">
+            <img src="foobar" srcSet="srcset" alt="An alt attribute for the img"/>
+            <figcaption>A caption</figcaption>
+          </figure>
+        );
+    });
 
-  it('renders a <img srcset="srcset" />', () => {
-    component
-      .should.have.deep.property('props.children[0].props.srcSet', 'srcset');
-  });
+    it('reflects props.srcSet to the <img> tag', () => {
+      renderer.render(<ImageCaption
+        caption="A caption"
+        src="src"
+        srcSet="foobar"
+        alt="An alt attribute for the img"
+      />, {});
+      renderer.getRenderOutput().should.deep.equal(
+          <figure className="ImageCaption">
+            <img src="src" srcSet="foobar" alt="An alt attribute for the img"/>
+            <figcaption>A caption</figcaption>
+          </figure>
+        );
+    });
 
-  it('renders a <img alt="An alt attribute for the img" />', () => {
-    component
-      .should.have.deep.property('props.children[0].props.alt', 'An alt attribute for the img');
-  });
+    it('reflects props.alt to the <img> tag', () => {
+      renderer.render(<ImageCaption
+        caption="A caption"
+        src="src"
+        srcSet="srcset"
+        alt="foobar"
+      />, {});
+      renderer.getRenderOutput().should.deep.equal(
+          <figure className="ImageCaption">
+            <img src="src" srcSet="srcset" alt="foobar"/>
+            <figcaption>A caption</figcaption>
+          </figure>
+        );
+    });
 
-  it('renders a <figcaption />"', () => {
-    component
-      .should.have.deep.property('props.children[1].type', 'figcaption');
-  });
+    it('reflects props.caption as the <figcaption> text', () => {
+      renderer.render(<ImageCaption
+        caption="foobar"
+        src="src"
+        srcSet="srcset"
+        alt="An alt attribute for the img"
+      />, {});
+      renderer.getRenderOutput().should.deep.equal(
+          <figure className="ImageCaption">
+            <img src="src" srcSet="srcset" alt="An alt attribute for the img"/>
+            <figcaption>foobar</figcaption>
+          </figure>
+        );
+    });
 
-  it('renders a <figcaption>A caption</figcaption>"', () => {
-    component
-      .should.have.deep.property('props.children[1].props.children', 'A caption');
+    it('does not render <figcaption> if props.caption is omitted', () => {
+      renderer.render(<ImageCaption
+        src="src"
+        srcSet="srcset"
+        alt="An alt attribute for the img"
+      />, {});
+      renderer.getRenderOutput().should.deep.equal(
+          <figure className="ImageCaption">
+            <img src="src" srcSet="srcset" alt="An alt attribute for the img"/>
+            {null}
+          </figure>
+        );
+    });
   });
 });


### PR DESCRIPTION
Switch to testing using `deep.equal` in combination with JSX,
allowing for more readable tests, even if they do veer slightly
into more behaviour style tests.

The main code has been refactored slightly to accomdate this, and
clean things up. `figcaption` is either `null` or the element,
whereas before it was an empty string. Also `srcset` is now `srcSet`
to maintain consistency with Reacts camel casing conventions.

Because of `srcset` now becoming `srcSet`, this change is a
SEMVER.MAJOR change.